### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ function Example() {
 ## API Reference
 
 ```js
-const { status, data, run, cancel, reset } = useStatefulPromis(
+const { status, data, run, cancel, reset } = useStatefulPromise(
   asyncFunction,
   initialData,
   {


### PR DESCRIPTION
Fixes a minor typo in the README.


Addresses https://github.com/Kornil/react-use-stateful-promise/issues/10
